### PR TITLE
gradio ui support config for sample size and sample rate

### DIFF
--- a/stable_audio_tools/interface/gradio.py
+++ b/stable_audio_tools/interface/gradio.py
@@ -35,8 +35,6 @@ os.environ['TMPDIR'] = './tmp'
 
 current_model_name = None
 current_model = None
-current_sample_rate = None
-current_sample_size = None
 
 
 
@@ -88,6 +86,8 @@ def generate_cond(
         cfg_scale=6.0,
         steps=250,
         preview_every=None,
+        sample_size=485100,
+        sample_rate=44100,
         seed=-1,
         sampler_type="dpmpp-3m-sde",
         sigma_min=0.03,
@@ -137,9 +137,9 @@ def generate_cond(
     else:
         model_config = None
     target_fps = model_config.get("video_fps", 5)
-    global current_model_name, current_model, current_sample_rate, current_sample_size
+    global current_model_name, current_model
     if current_model is None or model_name != current_model_name:
-        current_model, model_config, sample_rate, sample_size = load_model(
+        current_model, model_config, _, _ = load_model(
             model_name=model_name,
             model_config=model_config,
             model_ckpt_path=ckpt_path,
@@ -150,12 +150,10 @@ def generate_cond(
         )
         current_model_name = model_name
         model = current_model
-        current_sample_rate = sample_rate
-        current_sample_size = sample_size
     else:
         model = current_model
-        sample_rate = current_sample_rate
-        sample_size = current_sample_size
+    sample_rate = int(sample_rate)
+    sample_size = int(sample_size)
     if video_file is not None:
         video_path = video_file.name
     elif video_path:
@@ -334,6 +332,8 @@ def create_sampling_ui(model_config_map, inpainting=False):
                         steps_slider = gr.Slider(minimum=1, maximum=500, step=1, value=100, label="Steps")
                         preview_every_slider = gr.Slider(minimum=0, maximum=100, step=1, value=0, label="Preview Every")
                         cfg_scale_slider = gr.Slider(minimum=0.0, maximum=25.0, step=0.1, value=7.0, label="CFG Scale")
+                        sample_size_textbox = gr.Textbox(label="Sample Size (Sample Size / Sample Rate = Audio Duration)", value="485100")
+                        sample_rate_textbox = gr.Textbox(label="Sample Rate (Sample Size / Sample Rate = Audio Duration)", value="44100")
                         seed_textbox = gr.Textbox(label="Seed (set to -1 for random seed)", value="-1")
                         sampler_type_dropdown = gr.Dropdown(
                             ["dpmpp-2m-sde", "dpmpp-3m-sde", "k-heun", "k-lms", "k-dpmpp-2s-ancestral", "k-dpm-2", "k-dpm-fast"],
@@ -418,7 +418,9 @@ def create_sampling_ui(model_config_map, inpainting=False):
                 seconds_total_slider, 
                 cfg_scale_slider, 
                 steps_slider, 
-                preview_every_slider, 
+                preview_every_slider,
+                sample_size_textbox,
+                sample_rate_textbox,
                 seed_textbox, 
                 sampler_type_dropdown, 
                 sigma_min_slider, 


### PR DESCRIPTION
First of all, thank you very much for your great work!
While using AudioX in-depth, I found it inconvenient that I couldn't adjust the length of the output audio on Gradio. To address this, I optimized the code by adding two parameters, simple_rate and simple_size, to Gradio. I believe this enhancement will be useful for everyone, as it allows users to freely adjust the length of the audio output. Additionally, I have verified that this code is functional.